### PR TITLE
Update aws-actions/configure-aws-credentials to v2

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v3
       
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/eksDeploy.yml
+++ b/.github/workflows/eksDeploy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v3
       
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
v1 of aws-actions/configure-aws-credentials will deprecate soon hence please update to v2.

Check the warnings on this recent run https://github.com/AdminTurnedDevOps/kubernetes-real-world-course/actions/runs/5113533667

<img width="1405" alt="Screenshot 2023-05-29 at 7 43 35 PM" src="https://github.com/AdminTurnedDevOps/kubernetes-real-world-course/assets/5631327/1e8edd1e-e4c7-410a-bbad-c980be5f0511">
